### PR TITLE
Use Dir.home rather than tilde as shell expansion not working

### DIFF
--- a/lib/rake-terraform/default_tasks.rb
+++ b/lib/rake-terraform/default_tasks.rb
@@ -4,7 +4,8 @@ require 'pathname'
 namespace :terraform do
   env_glob = ENV['TERRAFORM_ENVIRONMENT_GLOB'] || 'terraform/**/*.tf'
   output_base = ENV['TERRAFORM_OUTPUT_BASE'] || 'output/terraform'
-  credential_file = ENV['TERRAFORM_CREDENTIAL_FILE'] || '~/.aws/credentials'
+  credential_file = ENV['TERRAFORM_CREDENTIAL_FILE']
+  credential_file ||= "#{Dir.home}/.aws/credentials"
   aws_project = ENV['TERRAFORM_AWS_PROJECT'] || 'default'
 
   # Set to string 'false' instead of bool so users can more-easily override


### PR DESCRIPTION
The default path for the credentials file uses a tilde, rather than the cross-platform `Dir.home` (available on ruby 1.9.3 and later).

Tilde is only expanded to mean the users home directory by the shell (or by File.expand_path). On my system (Debian 8, bash, ruby 2.1.1), running any rake task (through strace) with the default settings results in an `ENOENT` for a literal/unexpanded file `~/.aws/credentials` from the root of the filesystem.

I can see in `RakeTerraform::PlanTask::Config` that there is a `default_credentials` method that uses the tilde string, and then passes it through File.expand_path so the above tilde expansion would work; but as the default `terraform_plan` task explicitly configures the fall-through value to this string, the expanded default path is never used.

In any case - this one-liner fixes default behaviour.
