### PR TITLE
Update basetask.rb

### DIFF
--- a/lib/rake-terraform/basetask.rb
+++ b/lib/rake-terraform/basetask.rb
@@ -20,9 +20,9 @@ module RakeTerraform
 
     def get_aws_credentials(creds_file, project = 'default')
       error = "Could not locate AWS credentials in #{creds_file}!"
-      fail error unless File.exist? creds_file
+      fail error unless File.exist? File.expand_path(creds_file)
 
-      credentials = IniParse.parse(File.read(creds_file))
+      credentials = IniParse.parse(File.read(File.expand_path(creds_file)))
       { accesskey: credentials[project]['aws_access_key_id'],
         secretkey: credentials[project]['aws_secret_access_key'] }
     end


### PR DESCRIPTION
fixing creds_file path on Mac which doesn't find/like the home '~' path construction with out using 'File.expand_path' there maybe a more elegant way to do this but this is working on Mac