### PR TITLE
Add an Init task for newer Terraform

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,13 @@ Style/FileName:
   Exclude:
     # usability - module name should match the gem name
     - 'lib/rake-terraform.rb'
+Style/EndOfLine:
+  EnforcedStyle: lf
+Style/BlockLength:
+  Exclude:
+    - 'Rakefile'
+    - 'spec/**/*.rb'
+    - 'lib/rake-terraform/default_tasks.rb'
 Metrics/AbcSize:
   Exclude:
     # TODO - fix this

--- a/Rakefile
+++ b/Rakefile
@@ -9,13 +9,13 @@ namespace :test do
   # default unit tests
   desc 'Run all unit tests in default spec suite'
   RSpec::Core::RakeTask.new(:unit) do |task|
-    task.pattern = 'spec/(unit|rake-terraform)/*_spec.rb'
+    task.pattern = 'spec/unit/*_spec.rb'
   end
   # add rubocop tasks to test namespace
   RuboCop::RakeTask.new
   # run all non-integration/default tests
   desc 'Run all default test suites'
-  task default: [:unit, :rubocop]
+  task default: %i[unit rubocop]
 end
 
 # default task is to run all the default test suites

--- a/lib/rake-terraform/default_tasks.rb
+++ b/lib/rake-terraform/default_tasks.rb
@@ -28,6 +28,12 @@ namespace :terraform do
     abs_relative_path = relative_to_current.relative_path_from(env_glob_root)
 
     short_name = abs_relative_path.to_s.tr('/', '_')
+
+    desc "Initialize Terraform for use in #{short_name}"
+    terraform_init "init_#{short_name}" do |t|
+      t.input_dir = env
+    end
+
     plan_path = File.expand_path File.join(output_base, "#{short_name}.tf")
     desc "Plan migration of #{short_name}" if hide_tasks == 'false'
     terraform_plan "plan_#{short_name}" do |t|
@@ -44,7 +50,7 @@ namespace :terraform do
     end
 
     desc "Plan and migrate #{short_name}" if hide_tasks == 'false'
-    task short_name => %W(plan_#{short_name} apply_#{short_name})
+    task short_name => ["plan_#{short_name}", "apply_#{short_name}"]
   end
 
   desc 'Plan and migrate all environments'

--- a/lib/rake-terraform/dsl.rb
+++ b/lib/rake-terraform/dsl.rb
@@ -21,6 +21,15 @@ module RakeTerraform
         RakeTerraform::ApplyTask::Task.new(c.opts).execute
       end
     end
+
+    def terraform_init(*args)
+      require 'rake-terraform/inittask'
+      Rake::Task.define_task(*args) do
+        c = RakeTerraform::InitTask::Config.new
+        yield c
+        RakeTerraform::InitTask::Task.new(c.opts).execute
+      end
+    end
   end
 end
 

--- a/lib/rake-terraform/init_task/config.rb
+++ b/lib/rake-terraform/init_task/config.rb
@@ -1,0 +1,32 @@
+require 'rake-terraform/env_process'
+
+module RakeTerraform
+  module InitTask
+    # Configuration data for terraform plan task
+    class Config
+      prepend RakeTerraform::EnvProcess
+
+      def initialize
+        # initialize RakeTerraform::EnvProcess
+        super
+      end
+
+      def input_dir
+        @input_dir ||= File.expand_path 'terraform'
+      end
+
+      # setter method for input_dir triggers setters for tf_environment and
+      # state_file so that these are dynamically updated on change (but only if
+      # we are using directory state, and not explicit path to a state file)
+      def input_dir=(dir)
+        @tf_environment = dir
+        @state_file = tf_state_file if @state_dir
+        @input_dir = dir
+      end
+
+      def opts
+        Map.new(input_dir: input_dir)
+      end
+    end
+  end
+end

--- a/lib/rake-terraform/init_task/task.rb
+++ b/lib/rake-terraform/init_task/task.rb
@@ -1,0 +1,29 @@
+require 'rake-terraform/basetask'
+require 'rake-terraform/terraformcmd'
+module RakeTerraform
+  module InitTask
+    # Custom rake task to run `terraform plan`
+    class Task < BaseTask
+      include RakeTerraform::TerraformCmd
+
+      def initialize(opts)
+        @opts = opts
+      end
+
+      def execute
+        pre_execute_checks
+        Dir.chdir(@opts.get(:input_dir)) do
+          puts "=> Initializing Terraform for #{@opts.get(:input_dir)}..."
+          tf_init
+        end
+      end
+
+      private
+
+      # run pre execution checks
+      def pre_execute_checks
+        validate_terraform_installed
+      end
+    end
+  end
+end

--- a/lib/rake-terraform/inittask.rb
+++ b/lib/rake-terraform/inittask.rb
@@ -1,0 +1,13 @@
+require 'rake-terraform/init_task/config'
+require 'rake-terraform/init_task/task'
+# TODO: only needed in < 1.9?
+require 'map'
+
+module RakeTerraform
+  # == RakeTerraform::InitTask
+  #
+  # Helper classes for running terraform init
+  #
+  module InitTask
+  end
+end

--- a/lib/rake-terraform/terraformcmd.rb
+++ b/lib/rake-terraform/terraformcmd.rb
@@ -14,6 +14,13 @@ module RakeTerraform
       system(cmd)
     end
 
+    # perform a 'terraform init'
+    #
+    def tf_init
+      cmd = 'terraform init'
+      system(cmd)
+    end
+
     # perform a 'terraform plan'
     #
     # access_key and secret_key are optional as terraform and it's underlying

--- a/lib/rake-terraform/version.rb
+++ b/lib/rake-terraform/version.rb
@@ -1,4 +1,4 @@
 # Version of the gem
 module RakeTerraform
-  VERSION = '0.2.1'.freeze
+  VERSION = '0.2.2'.freeze
 end

--- a/rake-terraform.gemspec
+++ b/rake-terraform.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rake-terraform/version'
@@ -22,11 +23,11 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1'
-  spec.add_development_dependency 'rubocop', '~> 0.29'
-  spec.add_development_dependency 'rspec', '~> 3.0.0'
+  spec.add_development_dependency 'rubocop', '~> 0.49.1'
+  spec.add_development_dependency 'rspec', '~> 3.6.0'
   spec.add_dependency 'dotenv', '~> 2.0.0'
   spec.add_dependency 'wannabe_bool', '~> 0.3.0'
-  spec.add_dependency 'rake', '~> 10.0'
+  spec.add_dependency 'rake', '~> 12.0'
   spec.add_dependency 'map', '~> 6.5'
   spec.add_runtime_dependency 'highline', '~> 1.7'
   spec.add_runtime_dependency 'iniparse', '~> 1.3'

--- a/spec/unit/terraformcmd_spec.rb
+++ b/spec/unit/terraformcmd_spec.rb
@@ -169,6 +169,17 @@ module RakeTerraform
           end
         end
       end
+
+      describe 'tf_init' do
+        let(:default_init_cmd) { 'terraform init' }
+        context 'with no arguments' do
+          it 'should call terraform init' do
+            expect(test_class_inst).to receive(:system)
+              .with(default_init_cmd)
+            test_class_inst.tf_init
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Add bumped versions of rake, rspec, and rubocop
- Add small test for init task
- Cleaned up some misc rubocop complaints and added a few exceptions ( mostly for long blocks )
- Bumped version to 2.2 vs 3.0 as I assumed this is the "major" you had mentioned though I guess technically it would be x.3.0 let me know on this... 